### PR TITLE
Add /orders endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.23.2
 require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
-	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
+	github.com/stretchr/testify v1.10.0
 	go.mongodb.org/mongo-driver v1.17.3
 	golang.org/x/crypto v0.26.0
 )
@@ -35,7 +35,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,6 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -70,7 +68,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=

--- a/internal/domain/order/order.go
+++ b/internal/domain/order/order.go
@@ -3,9 +3,10 @@ package order
 type OrderStatus string
 
 const (
-	StatusPending   OrderStatus = "pending"
-	StatusShipped   OrderStatus = "shipped"
-	StatusDelivered OrderStatus = "delivered"
+	Pending   OrderStatus = "pending"
+	Shipped   OrderStatus = "shipped"
+	Delivered OrderStatus = "delivered"
+	Failed    OrderStatus = "failed"
 )
 
 type Order struct {

--- a/internal/infrastructure/mongo/order_repository.go
+++ b/internal/infrastructure/mongo/order_repository.go
@@ -1,0 +1,68 @@
+package mongo
+
+import (
+	"context"
+
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/order"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type mongoOrderRepository struct {
+	collection *mongo.Collection
+}
+
+func (r *mongoOrderRepository) UpdateOrderStatus(ctx context.Context, orderID string, status order.OrderStatus) error {
+	panic("unimplemented")
+}
+
+func (r *mongoOrderRepository) DeleteOrder(ctx context.Context, orderID string) error {
+	_, err := r.collection.DeleteOne(ctx, bson.M{"_id": orderID})
+	return err
+}
+
+func (r *mongoOrderRepository) CreateOrder(ctx context.Context, o *order.Order) error {
+	_, err := r.collection.InsertOne(ctx, o)
+	return err
+}
+
+func NewMongoOrderRepository(db *mongo.Database) order.Repository {
+	return &mongoOrderRepository{
+		collection: db.Collection("orders"),
+	}
+}
+
+func (r *mongoOrderRepository) GetOrdersByConsumer(ctx context.Context, consumerID string) ([]*order.Order, error) {
+	var orders []*order.Order
+	cursor, err := r.collection.Find(ctx, bson.M{"consumer_id": consumerID}) // Query by consumer_id
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	for cursor.Next(ctx) {
+		var o order.Order
+		if err := cursor.Decode(&o); err != nil {
+			return nil, err
+		}
+		orders = append(orders, &o)
+	}
+
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
+
+	return orders, nil
+}
+
+func (r *mongoOrderRepository) GetOrderByID(ctx context.Context, orderID string) (*order.Order, error) {
+	var o order.Order
+	err := r.collection.FindOne(ctx, bson.M{"_id": orderID}).Decode(&o)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &o, nil
+}

--- a/internal/interface/controllers/consumer_controller.go
+++ b/internal/interface/controllers/consumer_controller.go
@@ -1,0 +1,108 @@
+package controllers
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/order"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/models/common"
+	"github.com/gin-gonic/gin"
+)
+
+type ConsumerController struct {
+	orderRepo order.Repository
+}
+
+func NewConsumerController(orderRepo order.Repository) *ConsumerController {
+	return &ConsumerController{orderRepo: orderRepo}
+}
+
+func (c *ConsumerController) GetOrderHistory(ctx *gin.Context) {
+	userID, exists := ctx.Get("userID")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, common.APIResponse{
+			Success: false,
+			Message: "Unauthorized",
+		})
+		return
+	}
+
+	status := ctx.Query("status")
+	page, _ := strconv.Atoi(ctx.DefaultQuery("page", "1"))
+	limit, _ := strconv.Atoi(ctx.DefaultQuery("limit", "10"))
+
+	orders, err := c.orderRepo.GetOrdersByConsumer(ctx, userID.(string)) // Fetch orders by consumer ID
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, common.APIResponse{
+			Success: false,
+			Message: "Failed to fetch orders",
+		})
+		return
+	}
+
+	// Simulate delivery status
+	for i := range orders {
+		createdAt, _ := time.Parse(time.RFC3339, orders[i].CreatedAt)
+		if time.Since(createdAt) > 3*time.Minute && orders[i].Status == order.Pending {
+			orders[i].Status = order.Delivered
+		}
+	}
+
+	// Filter by status if provided
+	if status != "" {
+		filteredOrders := []*order.Order{}
+		for _, o := range orders {
+			if string(o.Status) == status {
+				filteredOrders = append(filteredOrders, o)
+			}
+		}
+		orders = filteredOrders
+	}
+
+	// Sort orders by CreatedAt in descending order
+	sort.Slice(orders, func(i, j int) bool {
+		return orders[i].CreatedAt > orders[j].CreatedAt
+	})
+
+	// Paginate results
+	start := (page - 1) * limit
+	end := start + limit
+	if start > len(orders) {
+		start = len(orders)
+	}
+	if end > len(orders) {
+		end = len(orders)
+	}
+	paginatedOrders := orders[start:end]
+
+	// Map to response format
+	var response []map[string]interface{}
+	for _, o := range paginatedOrders {
+		response = append(response, map[string]interface{}{
+			"orderId":               o.ID,
+			"itemTitle":             o.ProductIDs[0], // Assuming single product per order for simplicity
+			"price":                 o.TotalPrice,
+			"imageUrl":              "https://example.com/image.jpg", // Placeholder
+			"status":                o.Status,
+			"purchaseDate":          o.CreatedAt,
+			"estimatedDeliveryTime": "3 minutes",
+		})
+	}
+
+	if len(response) == 0 {
+		ctx.JSON(http.StatusOK, common.APIResponse{
+			Success: true,
+			Message: "No orders yet.",
+			Data:    []map[string]interface{}{},
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, common.APIResponse{
+		Success: true,
+		Message: "Orders retrieved successfully",
+		Data:    response,
+	})
+}

--- a/internal/interface/controllers/consumer_controller_test.go
+++ b/internal/interface/controllers/consumer_controller_test.go
@@ -1,0 +1,116 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/order"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type MockOrderRepository struct {
+	mock.Mock
+}
+
+func (m *MockOrderRepository) CreateOrder(ctx context.Context, o *order.Order) error {
+	args := m.Called(ctx, o)
+	return args.Error(0)
+}
+
+func (m *MockOrderRepository) GetOrdersByConsumer(ctx context.Context, consumerID string) ([]*order.Order, error) {
+	args := m.Called(ctx, consumerID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*order.Order), args.Error(1)
+}
+
+func (m *MockOrderRepository) GetOrderByID(ctx context.Context, orderID string) (*order.Order, error) {
+	args := m.Called(ctx, orderID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*order.Order), args.Error(1)
+}
+
+func (m *MockOrderRepository) UpdateOrderStatus(ctx context.Context, orderID string, status order.OrderStatus) error {
+	args := m.Called(ctx, orderID, status)
+	return args.Error(0)
+}
+
+func (m *MockOrderRepository) DeleteOrder(ctx context.Context, orderID string) error {
+	args := m.Called(ctx, orderID)
+	return args.Error(0)
+}
+
+type ConsumerControllerTestSuite struct {
+	suite.Suite
+	mockRepo    *MockOrderRepository
+	controller  *ConsumerController
+	testContext *gin.Context
+	recorder    *httptest.ResponseRecorder
+}
+
+func (suite *ConsumerControllerTestSuite) SetupTest() {
+	suite.mockRepo = new(MockOrderRepository)
+	suite.controller = NewConsumerController(suite.mockRepo)
+
+	// Set up a Gin context and response recorder for testing
+	gin.SetMode(gin.TestMode)
+	suite.recorder = httptest.NewRecorder()
+	suite.testContext, _ = gin.CreateTestContext(suite.recorder)
+}
+
+func (suite *ConsumerControllerTestSuite) TestGetOrderHistory_Success() {
+	orders := []*order.Order{
+		{
+			ID:         "order1",
+			ConsumerID: "consumer1",
+			ProductIDs: []string{"product1"},
+			TotalPrice: 100.0,
+			Status:     order.Pending,
+			CreatedAt:  time.Now().Add(-5 * time.Minute).Format(time.RFC3339),
+		},
+	}
+
+	suite.mockRepo.On("GetOrdersByConsumer", mock.Anything, "consumer1").Return(orders, nil)
+
+	suite.testContext.Set("userID", "consumer1")
+	suite.controller.GetOrderHistory(suite.testContext)
+
+	assert.Equal(suite.T(), http.StatusOK, suite.recorder.Code)
+	suite.mockRepo.AssertExpectations(suite.T())
+}
+
+func (suite *ConsumerControllerTestSuite) TestGetOrderHistory_NoOrders() {
+	suite.mockRepo.On("GetOrdersByConsumer", mock.Anything, "consumer1").Return([]*order.Order{}, nil)
+
+	suite.testContext.Set("userID", "consumer1")
+	suite.controller.GetOrderHistory(suite.testContext)
+
+	assert.Equal(suite.T(), http.StatusOK, suite.recorder.Code)
+	assert.Contains(suite.T(), suite.recorder.Body.String(), "No orders yet.")
+	suite.mockRepo.AssertExpectations(suite.T())
+}
+
+func (suite *ConsumerControllerTestSuite) TestGetOrderHistory_ErrorFetchingOrders() {
+	suite.mockRepo.On("GetOrdersByConsumer", mock.Anything, "consumer1").Return(nil, errors.New("database error"))
+
+	suite.testContext.Set("userID", "consumer1")
+	suite.controller.GetOrderHistory(suite.testContext)
+
+	assert.Equal(suite.T(), http.StatusInternalServerError, suite.recorder.Code)
+	assert.Contains(suite.T(), suite.recorder.Body.String(), "Failed to fetch orders")
+	suite.mockRepo.AssertExpectations(suite.T())
+}
+
+func TestConsumerControllerTestSuite(t *testing.T) {
+	suite.Run(t, new(ConsumerControllerTestSuite))
+}

--- a/internal/interface/routes/consumer_routes.go
+++ b/internal/interface/routes/consumer_routes.go
@@ -1,0 +1,15 @@
+package routes
+
+import (
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/auth"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/interface/controllers"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/interface/middlewares"
+	"github.com/gin-gonic/gin"
+)
+
+func RegisterConsumerRoutes(r *gin.Engine, ctrl *controllers.ConsumerController, jwtSvc auth.JWTService) {
+	consumerGroup := r.Group("/orders")
+	consumerGroup.Use(middlewares.AuthMiddleware(jwtSvc))
+
+	consumerGroup.GET("/history", middlewares.AuthorizeRoles("consumer"), ctrl.GetOrderHistory) 
+}

--- a/internal/interface/routes/product_routes.go
+++ b/internal/interface/routes/product_routes.go
@@ -9,7 +9,7 @@ import (
 
 func RegisterProductRoutes(r *gin.Engine, ctrl *controllers.ProductController, jwtSvc auth.JWTService) {
 	productGroup := r.Group("/products")
-	productGroup.Use(middlewares.AuthMiddleware(jwtSvc)) // All routes require valid token
+	productGroup.Use(middlewares.AuthMiddleware(jwtSvc)) 
 
 	productGroup.POST("", middlewares.AuthorizeRoles("reseller", "admin"), ctrl.Create)
 	productGroup.GET("/:id", middlewares.AuthorizeRoles("consumer", "reseller", "admin"), ctrl.GetByID)

--- a/models/order.go
+++ b/models/order.go
@@ -5,8 +5,12 @@ type OrderRequest struct {
 }
 
 type OrderResponse struct {
-	ID      string          `json:"id"`
-	BuyerID string          `json:"buyer_id"`
-	Product ProductResponse `json:"product"`
-	Status  string          `json:"status"`
+	ID                    string  `json:"id"`
+	BuyerID               string  `json:"buyer_id"`
+	ProductTitle          string  `json:"product_title"`
+	Status                string  `json:"status"`
+	TotalPrice            float64 `json:"total_price"`
+	CreatedAt             string  `json:"created_at"`
+	ImageURL              string  `json:"image_url"`
+	EstimatedDeliveryTime string  `json:"estimated_delivery_time"`
 }


### PR DESCRIPTION
## Feature: Consumer Order History API with Filters and Simulated Delivery

###  Description

This PR adds a new endpoint for **consumers to view their past purchases**, complete with:

- Delivery status simulation (`pending` → `delivered` after 3 minutes)
- Status filtering (`pending`, `delivered`, `failed`)
- Pagination with default `page=1`, `limit=10`
- Role-based access control (only consumers can access)



