### PR TITLE
Test controllers

### DIFF
--- a/internal/interface/controllers/admin_controller_test.go
+++ b/internal/interface/controllers/admin_controller_test.go
@@ -1,0 +1,205 @@
+package controllers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/user"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type MockUserUsecase struct {
+	mock.Mock
+}
+
+func (m *MockUserUsecase) ListByRole(ctx context.Context, role user.Role) ([]*user.User, error) {
+	args := m.Called(ctx, role)
+	return args.Get(0).([]*user.User), args.Error(1)
+}
+
+func (m *MockUserUsecase) GetByID(ctx context.Context, id string) (*user.User, error) {
+	args := m.Called(ctx, id)
+	return args.Get(0).(*user.User), args.Error(1)
+}
+
+func (m *MockUserUsecase) Update(ctx context.Context, id string, updates map[string]interface{}) error {
+	args := m.Called(ctx, id, updates)
+	return args.Error(0)
+}
+
+func (m *MockUserUsecase) GetBlacklistedUsers(ctx context.Context) ([]*user.User, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*user.User), args.Error(1)
+}
+
+func (m *MockUserUsecase) Delete(ctx context.Context, id string) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockUserUsecase) GetByEmail(ctx context.Context, email string) (*user.User, error) {
+	args := m.Called(ctx, email)
+	return args.Get(0).(*user.User), args.Error(1)
+}
+
+type AdminControllerTestSuite struct {
+	suite.Suite
+	controller *AdminController
+	mockUC     *MockUserUsecase
+	router     *gin.Engine
+}
+
+func (suite *AdminControllerTestSuite) SetupTest() {
+	suite.mockUC = new(MockUserUsecase)
+	suite.controller = NewAdminController(suite.mockUC)
+	gin.SetMode(gin.TestMode)
+	suite.router = gin.Default()
+}
+
+func (suite *AdminControllerTestSuite) TestGetAllUsers_NoRoleParam() {
+	// Setup
+	users := []*user.User{
+		{ID: "1", Name: "User1", Role: string(user.RoleSupplier)},
+		{ID: "2", Name: "User2", Role: string(user.RoleConsumer)},
+	}
+
+	suite.mockUC.On("ListByRole", mock.Anything, user.RoleSupplier).Return(users[:1], nil)
+	suite.mockUC.On("ListByRole", mock.Anything, user.RoleReseller).Return([]*user.User{}, nil)
+	suite.mockUC.On("ListByRole", mock.Anything, user.RoleConsumer).Return(users[1:], nil)
+	suite.mockUC.On("ListByRole", mock.Anything, user.RoleAdmin).Return([]*user.User{}, nil)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/admin/users", nil)
+	suite.router.GET("/api/admin/users", suite.controller.GetAllUsers)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *AdminControllerTestSuite) TestGetAllUsers_WithRoleParam() {
+	// Setup
+	users := []*user.User{
+		{ID: "1", Name: "User1", Role: string(user.RoleSupplier)},
+	}
+	suite.mockUC.On("ListByRole", mock.Anything, user.RoleSupplier).Return(users, nil)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/admin/users?role=supplier", nil)
+	suite.router.GET("/api/admin/users", suite.controller.GetAllUsers)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *AdminControllerTestSuite) TestDeleteUserIfBlacklisted_Success() {
+	// Setup
+	userID := "1"
+	userData := &user.User{
+		ID:         userID,
+		Role:       string(user.RoleSupplier),
+		TrustScore: 50,
+	}
+	suite.mockUC.On("GetByID", mock.Anything, userID).Return(userData, nil)
+	suite.mockUC.On("Update", mock.Anything, userID, map[string]interface{}{"is_deleted": true}).Return(nil)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/admin/users/"+userID, nil)
+	suite.router.DELETE("/api/admin/users/:userId", suite.controller.DeleteUserIfBlacklisted)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *AdminControllerTestSuite) TestDeleteUserIfBlacklisted_UserNotFound() {
+	// Setup
+	userID := "1"
+	suite.mockUC.On("GetByID", mock.Anything, userID).Return((*user.User)(nil), nil)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/admin/users/"+userID, nil)
+	suite.router.DELETE("/api/admin/users/:userId", suite.controller.DeleteUserIfBlacklisted)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusNotFound, w.Code)
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *AdminControllerTestSuite) TestDeleteUserIfBlacklisted_InvalidRole() {
+	// Setup
+	userID := "1"
+	userData := &user.User{
+		ID:         userID,
+		Role:       string(user.RoleConsumer),
+		TrustScore: 50,
+	}
+	suite.mockUC.On("GetByID", mock.Anything, userID).Return(userData, nil)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/admin/users/"+userID, nil)
+	suite.router.DELETE("/api/admin/users/:userId", suite.controller.DeleteUserIfBlacklisted)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusForbidden, w.Code)
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *AdminControllerTestSuite) TestGetTrustScores_AllRoles() {
+	// Setup
+	users := []*user.User{
+		{ID: "1", Name: "User1", Role: string(user.RoleSupplier), TrustScore: 70},
+		{ID: "2", Name: "User2", Role: string(user.RoleReseller), TrustScore: 50},
+	}
+	suite.mockUC.On("ListByRole", mock.Anything, user.RoleSupplier).Return(users[:1], nil)
+	suite.mockUC.On("ListByRole", mock.Anything, user.RoleReseller).Return(users[1:], nil)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/admin/trust-scores", nil)
+	suite.router.GET("/api/admin/trust-scores", suite.controller.GetTrustScores)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *AdminControllerTestSuite) TestGetBlacklistedUsers() {
+	// Setup
+	users := []*user.User{
+		{ID: "1", Name: "User1", Role: string(user.RoleSupplier), TrustScore: 50},
+		{ID: "2", Name: "User2", Role: string(user.RoleReseller), TrustScore: 40},
+	}
+	suite.mockUC.On("GetBlacklistedUsers", mock.Anything).Return(users, nil)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/admin/blacklisted-users", nil)
+	suite.router.GET("/api/admin/blacklisted-users", suite.controller.GetBlacklistedUsers)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func TestAdminControllerSuite(t *testing.T) {
+	suite.Run(t, new(AdminControllerTestSuite))
+}

--- a/internal/interface/controllers/auth_controller_test.go
+++ b/internal/interface/controllers/auth_controller_test.go
@@ -1,0 +1,188 @@
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/auth"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/user"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type MockAuthUsecase struct {
+	mock.Mock
+}
+
+func (m *MockAuthUsecase) Register(ctx context.Context, user user.User) (string, error) {
+	args := m.Called(ctx, user)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockAuthUsecase) Login(ctx context.Context, creds auth.LoginCredentials) (string, error) {
+	args := m.Called(ctx, creds)
+	return args.String(0), args.Error(1)
+}
+
+type AuthControllerTestSuite struct {
+	suite.Suite
+	controller *AuthController
+	mockUC     *MockAuthUsecase
+	router     *gin.Engine
+}
+
+func (suite *AuthControllerTestSuite) SetupTest() {
+	suite.mockUC = new(MockAuthUsecase)
+	suite.controller = NewAuthController(suite.mockUC)
+	gin.SetMode(gin.TestMode)
+	suite.router = gin.Default()
+}
+
+func (suite *AuthControllerTestSuite) TestRegister_Success() {
+	// Setup
+	newUser := user.User{
+		Name:     "Test User",
+		Email:    "test@example.com",
+		Password: "password123",
+		Role:     string(user.RoleConsumer),
+	}
+	token := "test-token"
+
+	suite.mockUC.On("Register", mock.Anything, newUser).Return(token, nil)
+
+	// Execute
+	jsonData, _ := json.Marshal(newUser)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/auth/register", bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	suite.router.POST("/auth/register", suite.controller.Register)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusCreated, w.Code)
+	var response map[string]string
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.Equal(suite.T(), token, response["token"])
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *AuthControllerTestSuite) TestRegister_InvalidRequest() {
+	// Setup
+	invalidUser := "invalid json"
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/auth/register", bytes.NewBuffer([]byte(invalidUser)))
+	req.Header.Set("Content-Type", "application/json")
+	suite.router.POST("/auth/register", suite.controller.Register)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+}
+
+func (suite *AuthControllerTestSuite) TestRegister_Conflict() {
+	// Setup
+	newUser := user.User{
+		Name:     "Test User",
+		Email:    "test@example.com",
+		Password: "password123",
+		Role:     string(user.RoleConsumer),
+	}
+	errorMsg := "user already exists"
+
+	suite.mockUC.On("Register", mock.Anything, newUser).Return("", errors.New(errorMsg))
+
+	// Execute
+	jsonData, _ := json.Marshal(newUser)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/auth/register", bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	suite.router.POST("/auth/register", suite.controller.Register)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusConflict, w.Code)
+	var response map[string]string
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.Equal(suite.T(), errorMsg, response["error"])
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *AuthControllerTestSuite) TestLogin_Success() {
+	// Setup
+	creds := auth.LoginCredentials{
+		Username: "test@example.com",
+		Password: "password123",
+	}
+	token := "test-token"
+
+	suite.mockUC.On("Login", mock.Anything, creds).Return(token, nil)
+
+	// Execute
+	jsonData, _ := json.Marshal(creds)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/auth/login", bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	suite.router.POST("/auth/login", suite.controller.Login)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	var response map[string]string
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.Equal(suite.T(), token, response["token"])
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *AuthControllerTestSuite) TestLogin_InvalidRequest() {
+	// Setup
+	invalidCreds := "invalid json"
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/auth/login", bytes.NewBuffer([]byte(invalidCreds)))
+	req.Header.Set("Content-Type", "application/json")
+	suite.router.POST("/auth/login", suite.controller.Login)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+}
+
+func (suite *AuthControllerTestSuite) TestLogin_Unauthorized() {
+	// Setup
+	creds := auth.LoginCredentials{
+		Username: "test@example.com",
+		Password: "wrongpassword",
+	}
+	errorMsg := "invalid username or password"
+
+	suite.mockUC.On("Login", mock.Anything, creds).Return("", errors.New(errorMsg))
+
+	// Execute
+	jsonData, _ := json.Marshal(creds)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/auth/login", bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	suite.router.POST("/auth/login", suite.controller.Login)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+	var response map[string]string
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.Equal(suite.T(), errorMsg, response["error"])
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func TestAuthControllerSuite(t *testing.T) {
+	suite.Run(t, new(AuthControllerTestSuite))
+}

--- a/internal/interface/controllers/bundle_controller_test.go
+++ b/internal/interface/controllers/bundle_controller_test.go
@@ -1,0 +1,315 @@
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/bundle"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/user"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/models"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/models/common"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type MockBundleUsecase struct {
+	mock.Mock
+}
+
+func (m *MockBundleUsecase) CreateBundle(ctx context.Context, supplierID string, b *bundle.Bundle) error {
+	args := m.Called(ctx, supplierID, b)
+	return args.Error(0)
+}
+
+func (m *MockBundleUsecase) ListBundles(ctx context.Context, supplierID string) ([]*bundle.Bundle, error) {
+	args := m.Called(ctx, supplierID)
+	return args.Get(0).([]*bundle.Bundle), args.Error(1)
+}
+
+func (m *MockBundleUsecase) DeleteBundle(ctx context.Context, supplierID, bundleID string) error {
+	args := m.Called(ctx, supplierID, bundleID)
+	return args.Error(0)
+}
+
+func (m *MockBundleUsecase) UpdateBundle(ctx context.Context, supplierID, bundleID string, updates map[string]interface{}) error {
+	args := m.Called(ctx, supplierID, bundleID, updates)
+	return args.Error(0)
+}
+
+func (m *MockBundleUsecase) GetBundleByID(ctx context.Context, supplierID, bundleID string) (*bundle.Bundle, error) {
+	args := m.Called(ctx, supplierID, bundleID)
+	return args.Get(0).(*bundle.Bundle), args.Error(1)
+}
+
+func (m *MockBundleUsecase) GetBundlePublicByID(ctx context.Context, bundleID string) (*bundle.Bundle, error) {
+	args := m.Called(ctx, bundleID)
+	return args.Get(0).(*bundle.Bundle), args.Error(1)
+}
+
+func (m *MockBundleUsecase) ListAvailableBundles(ctx context.Context) ([]*bundle.Bundle, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*bundle.Bundle), args.Error(1)
+}
+
+func (m *MockBundleUsecase) DecreaseRemainingItemCount(ctx context.Context, bundleID string) error {
+	args := m.Called(ctx, bundleID)
+	return args.Error(0)
+}
+
+type BundleControllerTestSuite struct {
+	suite.Suite
+	controller    *BundleController
+	mockBundleUC  *MockBundleUsecase
+	mockUserUC    *MockUserUsecase
+	router        *gin.Engine
+	supplierID    string
+	supplierToken string
+}
+
+func (suite *BundleControllerTestSuite) SetupTest() {
+	suite.mockBundleUC = new(MockBundleUsecase)
+	suite.mockUserUC = new(MockUserUsecase)
+	suite.controller = NewBundleController(suite.mockBundleUC, suite.mockUserUC)
+	gin.SetMode(gin.TestMode)
+	suite.router = gin.Default()
+	suite.supplierID = "supplier123"
+	suite.supplierToken = "supplier-token"
+
+	// Add auth middleware
+	suite.router.Use(func(c *gin.Context) {
+		c.Set("userID", suite.supplierID)
+		c.Set("role", "supplier")
+	})
+}
+
+func (suite *BundleControllerTestSuite) TestCreateBundle_Success() {
+	// Setup
+	req := models.CreateBundleRequest{
+		Title:              "Test Bundle",
+		Description:        "Test Description",
+		SampleImage:        "test.jpg",
+		NumberOfItems:      10,
+		Grade:              "A",
+		Type:               "basic",
+		EstimatedBreakdown: map[string]int{"shirts": 5, "pants": 5},
+		ClothingTypes:      []string{"shirt"},
+		Price:              100.0,
+		DeclaredRating:     4,
+	}
+
+	user := &user.User{
+		ID:            suite.supplierID,
+		IsBlacklisted: false,
+	}
+
+	suite.mockUserUC.On("GetByID", mock.Anything, suite.supplierID).Return(user, nil)
+	suite.mockBundleUC.On("CreateBundle", mock.Anything, suite.supplierID, mock.Anything).Return(nil)
+
+	// Execute
+	jsonData, _ := json.Marshal(req)
+	w := httptest.NewRecorder()
+	httpReq, _ := http.NewRequest("POST", "/bundles", bytes.NewBuffer(jsonData))
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+suite.supplierToken)
+	suite.router.POST("/bundles", suite.controller.CreateBundle)
+	suite.router.ServeHTTP(w, httpReq)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	var response common.APIResponse
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.True(suite.T(), response.Success)
+	suite.mockUserUC.AssertExpectations(suite.T())
+	suite.mockBundleUC.AssertExpectations(suite.T())
+}
+
+func (suite *BundleControllerTestSuite) TestCreateBundle_BlacklistedUser() {
+	// Setup
+	req := models.CreateBundleRequest{
+		Title:              "Test Bundle",
+		Description:        "Test Description",
+		SampleImage:        "test.jpg",
+		NumberOfItems:      10,
+		Grade:              "A",
+		Type:               "basic",
+		EstimatedBreakdown: map[string]int{"shirts": 5, "pants": 5},
+		ClothingTypes:      []string{"shirt"},
+		Price:              100.0,
+		DeclaredRating:     4,
+	}
+
+	user := &user.User{
+		ID:            suite.supplierID,
+		IsBlacklisted: true,
+	}
+
+	suite.mockUserUC.On("GetByID", mock.Anything, suite.supplierID).Return(user, nil)
+
+	// Execute
+	jsonData, _ := json.Marshal(req)
+	w := httptest.NewRecorder()
+	httpReq, _ := http.NewRequest("POST", "/bundles", bytes.NewBuffer(jsonData))
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+suite.supplierToken)
+	suite.router.POST("/bundles", suite.controller.CreateBundle)
+	suite.router.ServeHTTP(w, httpReq)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusForbidden, w.Code)
+	var response common.APIResponse
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.False(suite.T(), response.Success)
+	suite.mockUserUC.AssertExpectations(suite.T())
+}
+
+func (suite *BundleControllerTestSuite) TestListBundles_Success() {
+	// Setup
+	bundles := []*bundle.Bundle{
+		{
+			ID:           "bundle1",
+			Title:        "Test Bundle 1",
+			Grade:        "A",
+			Price:        100.0,
+			SortingLevel: "basic",
+			Status:       "available",
+		},
+	}
+
+	suite.mockBundleUC.On("ListBundles", mock.Anything, suite.supplierID).Return(bundles, nil)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/bundles", nil)
+	req.Header.Set("Authorization", "Bearer "+suite.supplierToken)
+	suite.router.GET("/bundles", suite.controller.ListBundles)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	var response common.APIResponse
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.True(suite.T(), response.Success)
+	suite.mockBundleUC.AssertExpectations(suite.T())
+}
+
+func (suite *BundleControllerTestSuite) TestDeleteBundle_Success() {
+	// Setup
+	bundleID := "bundle123"
+	suite.mockBundleUC.On("DeleteBundle", mock.Anything, suite.supplierID, bundleID).Return(nil)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/bundles/"+bundleID, nil)
+	req.Header.Set("Authorization", "Bearer "+suite.supplierToken)
+	suite.router.DELETE("/bundles/:id", suite.controller.DeleteBundle)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	var response common.APIResponse
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.True(suite.T(), response.Success)
+	suite.mockBundleUC.AssertExpectations(suite.T())
+}
+
+func (suite *BundleControllerTestSuite) TestUpdateBundle_Success() {
+	// Setup
+	bundleID := "bundle123"
+	updates := map[string]interface{}{
+		"title": "Updated Title",
+		"price": 150.0,
+	}
+
+	updatedBundle := &bundle.Bundle{
+		ID:           bundleID,
+		Title:        "Updated Title",
+		Grade:        "A",
+		Price:        150.0,
+		SortingLevel: "basic",
+		Status:       "available",
+	}
+
+	suite.mockBundleUC.On("UpdateBundle", mock.Anything, suite.supplierID, bundleID, updates).Return(nil)
+	suite.mockBundleUC.On("GetBundleByID", mock.Anything, suite.supplierID, bundleID).Return(updatedBundle, nil)
+
+	// Execute
+	jsonData, _ := json.Marshal(updates)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/bundles/"+bundleID, bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+suite.supplierToken)
+	suite.router.PUT("/bundles/:id", suite.controller.UpdateBundle)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	var response common.APIResponse
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.True(suite.T(), response.Success)
+	suite.mockBundleUC.AssertExpectations(suite.T())
+}
+
+func (suite *BundleControllerTestSuite) TestGetBundle_Success() {
+	// Setup
+	bundleID := "bundle123"
+	b := &bundle.Bundle{
+		ID:           bundleID,
+		Title:        "Test Bundle",
+		Grade:        "A",
+		Price:        100.0,
+		SortingLevel: "basic",
+		Status:       "available",
+	}
+
+	suite.mockBundleUC.On("GetBundleByID", mock.Anything, suite.supplierID, bundleID).Return(b, nil)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/bundles/"+bundleID, nil)
+	req.Header.Set("Authorization", "Bearer "+suite.supplierToken)
+	suite.router.GET("/bundles/:id", suite.controller.GetBundle)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	var response common.APIResponse
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.True(suite.T(), response.Success)
+	suite.mockBundleUC.AssertExpectations(suite.T())
+}
+
+func (suite *BundleControllerTestSuite) TestListAvailableBundles_Success() {
+	// Setup
+	bundles := []*bundle.Bundle{
+		{
+			ID:           "bundle1",
+			Title:        "Test Bundle 1",
+			Grade:        "A",
+			Price:        100.0,
+			SortingLevel: "basic",
+			Status:       "available",
+		},
+	}
+
+	suite.mockBundleUC.On("ListAvailableBundles", mock.Anything).Return(bundles, nil)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/bundles/available", nil)
+	suite.router.GET("/bundles/available", suite.controller.ListAvailableBundles)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.mockBundleUC.AssertExpectations(suite.T())
+}
+
+func TestBundleControllerSuite(t *testing.T) {
+	suite.Run(t, new(BundleControllerTestSuite))
+}

--- a/internal/interface/controllers/cartitem_controller_test.go
+++ b/internal/interface/controllers/cartitem_controller_test.go
@@ -1,0 +1,274 @@
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/cartitem"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/models"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type MockCartItemUsecase struct {
+	mock.Mock
+}
+
+func (m *MockCartItemUsecase) AddCartItem(ctx context.Context, userID, listingID string) error {
+	args := m.Called(ctx, userID, listingID)
+	return args.Error(0)
+}
+
+func (m *MockCartItemUsecase) GetCartItems(ctx context.Context, userID string) ([]*cartitem.CartItem, error) {
+	args := m.Called(ctx, userID)
+	return args.Get(0).([]*cartitem.CartItem), args.Error(1)
+}
+
+func (m *MockCartItemUsecase) RemoveCartItem(ctx context.Context, userID, listingID string) error {
+	args := m.Called(ctx, userID, listingID)
+	return args.Error(0)
+}
+
+func (m *MockCartItemUsecase) CheckoutCart(ctx context.Context, userID string) error {
+	args := m.Called(ctx, userID)
+	return args.Error(0)
+}
+
+type CartItemControllerTestSuite struct {
+	suite.Suite
+	controller *CartItemController
+	mockUC     *MockCartItemUsecase
+	router     *gin.Engine
+	userID     string
+}
+
+func (suite *CartItemControllerTestSuite) SetupTest() {
+	suite.mockUC = new(MockCartItemUsecase)
+	suite.controller = NewCartItemController(suite.mockUC)
+	gin.SetMode(gin.TestMode)
+	suite.router = gin.Default()
+	suite.userID = "user123"
+
+	// Add auth middleware
+	suite.router.Use(func(c *gin.Context) {
+		c.Set("userID", suite.userID)
+	})
+}
+
+func (suite *CartItemControllerTestSuite) TestAddCartItem_Success() {
+	// Setup
+	req := models.CreateCartItemRequest{
+		ListingID: "listing123",
+	}
+
+	suite.mockUC.On("AddCartItem", mock.Anything, suite.userID, req.ListingID).Return(nil)
+
+	// Execute
+	jsonData, _ := json.Marshal(req)
+	w := httptest.NewRecorder()
+	httpReq, _ := http.NewRequest("POST", "/api/cart", bytes.NewBuffer(jsonData))
+	httpReq.Header.Set("Content-Type", "application/json")
+	suite.router.POST("/api/cart", suite.controller.AddCartItem)
+	suite.router.ServeHTTP(w, httpReq)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusCreated, w.Code)
+	var response map[string]string
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.Equal(suite.T(), "item added to cart", response["message"])
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *CartItemControllerTestSuite) TestAddCartItem_Unauthorized() {
+	// Setup
+	req := models.CreateCartItemRequest{
+		ListingID: "listing123",
+	}
+
+	// Execute
+	jsonData, _ := json.Marshal(req)
+	w := httptest.NewRecorder()
+	httpReq, _ := http.NewRequest("POST", "/api/cart", bytes.NewBuffer(jsonData))
+	httpReq.Header.Set("Content-Type", "application/json")
+	// Remove auth middleware for this test
+	router := gin.Default()
+	router.POST("/api/cart", suite.controller.AddCartItem)
+	router.ServeHTTP(w, httpReq)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+}
+
+func (suite *CartItemControllerTestSuite) TestAddCartItem_InvalidRequest() {
+	// Setup
+	invalidReq := "invalid json"
+
+	// Execute
+	w := httptest.NewRecorder()
+	httpReq, _ := http.NewRequest("POST", "/api/cart", bytes.NewBuffer([]byte(invalidReq)))
+	httpReq.Header.Set("Content-Type", "application/json")
+	suite.router.POST("/api/cart", suite.controller.AddCartItem)
+	suite.router.ServeHTTP(w, httpReq)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+}
+
+func (suite *CartItemControllerTestSuite) TestGetCartItems_Success() {
+	// Setup
+	items := []*cartitem.CartItem{
+		{
+			ID:        "item1",
+			ListingID: "listing1",
+			Title:     "Test Item 1",
+			Price:     100.0,
+			ImageURL:  "image1.jpg",
+			Grade:     "A",
+			CreatedAt: time.Now(),
+		},
+	}
+
+	suite.mockUC.On("GetCartItems", mock.Anything, suite.userID).Return(items, nil)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/cart", nil)
+	suite.router.GET("/api/cart", suite.controller.GetCartItems)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	var response []models.CartItemResponse
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.Len(suite.T(), response, 1)
+	assert.Equal(suite.T(), items[0].ID, response[0].ID)
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *CartItemControllerTestSuite) TestGetCartItems_Unauthorized() {
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/cart", nil)
+	// Remove auth middleware for this test
+	router := gin.Default()
+	router.GET("/api/cart", suite.controller.GetCartItems)
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+}
+
+func (suite *CartItemControllerTestSuite) TestRemoveCartItem_Success() {
+	// Setup
+	listingID := "listing123"
+	suite.mockUC.On("RemoveCartItem", mock.Anything, suite.userID, listingID).Return(nil)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/cart/items/"+listingID, nil)
+	suite.router.DELETE("/api/cart/items/:listingID", suite.controller.RemoveCartItem)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	var response map[string]string
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.Equal(suite.T(), "item removed from cart", response["message"])
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *CartItemControllerTestSuite) TestRemoveCartItem_Unauthorized() {
+	// Setup
+	listingID := "listing123"
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/cart/items/"+listingID, nil)
+	// Remove auth middleware for this test
+	router := gin.Default()
+	router.DELETE("/api/cart/items/:listingID", suite.controller.RemoveCartItem)
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+}
+
+func (suite *CartItemControllerTestSuite) TestCheckoutCart_Success() {
+	// Setup
+	suite.mockUC.On("CheckoutCart", mock.Anything, suite.userID).Return(nil)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/checkout", nil)
+	suite.router.POST("/api/checkout", suite.controller.CheckoutCart)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	var response map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.True(suite.T(), response["success"].(bool))
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *CartItemControllerTestSuite) TestCheckoutCart_ValidationError() {
+	// Setup
+	validationError := &cartitem.CheckoutValidationError{
+		Message: "Some items are unavailable",
+		UnavailableItems: []cartitem.UnavailableItem{
+			{ListingID: "item1", Title: "Test Item 1"},
+			{ListingID: "item2", Title: "Test Item 2"},
+		},
+	}
+	suite.mockUC.On("CheckoutCart", mock.Anything, suite.userID).Return(validationError)
+
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/checkout", nil)
+	suite.router.POST("/api/checkout", suite.controller.CheckoutCart)
+	suite.router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+	var response map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.False(suite.T(), response["success"].(bool))
+	assert.Equal(suite.T(), validationError.Message, response["message"])
+
+	// Convert unavailableItems to the expected type
+	unavailableItems := response["unavailableItems"].([]interface{})
+	var actualUnavailableItems []cartitem.UnavailableItem
+	for _, item := range unavailableItems {
+		itemMap := item.(map[string]interface{})
+		actualUnavailableItems = append(actualUnavailableItems, cartitem.UnavailableItem{
+			ListingID: itemMap["listingId"].(string),
+			Title:     itemMap["title"].(string),
+		})
+	}
+	assert.Equal(suite.T(), validationError.UnavailableItems, actualUnavailableItems)
+	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *CartItemControllerTestSuite) TestCheckoutCart_Unauthorized() {
+	// Execute
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/checkout", nil)
+	// Remove auth middleware for this test
+	router := gin.Default()
+	router.POST("/api/checkout", suite.controller.CheckoutCart)
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+}
+
+func TestCartItemControllerSuite(t *testing.T) {
+	suite.Run(t, new(CartItemControllerTestSuite))
+}

--- a/internal/interface/controllers/order_controller_test.go
+++ b/internal/interface/controllers/order_controller_test.go
@@ -1,0 +1,202 @@
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/order"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/payment"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/warehouse"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type OrderControllerTestSuite struct {
+	suite.Suite
+	orderUseCase *MockOrderUseCase
+	controller   *OrderController
+	router       *gin.Engine
+}
+
+type MockOrderUseCase struct {
+	mock.Mock
+}
+
+func (m *MockOrderUseCase) PurchaseBundle(ctx context.Context, bundleID, resellerID string) (*order.Order, *payment.Payment, *warehouse.WarehouseItem, error) {
+	args := m.Called(ctx, bundleID, resellerID)
+	if args.Get(0) == nil {
+		return nil, nil, nil, args.Error(3)
+	}
+	return args.Get(0).(*order.Order), args.Get(1).(*payment.Payment), args.Get(2).(*warehouse.WarehouseItem), args.Error(3)
+}
+
+func (m *MockOrderUseCase) GetOrderByID(ctx context.Context, orderID string) (*order.Order, error) {
+	args := m.Called(ctx, orderID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*order.Order), args.Error(1)
+}
+
+func (m *MockOrderUseCase) GetDashboardMetrics(ctx context.Context, supplierID string) (*order.DashboardMetrics, error) {
+	args := m.Called(ctx, supplierID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*order.DashboardMetrics), args.Error(1)
+}
+
+func (m *MockOrderUseCase) GetSoldBundleHistory(ctx context.Context, supplierID string) ([]*order.Order, error) {
+	args := m.Called(ctx, supplierID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*order.Order), args.Error(1)
+}
+
+func (suite *OrderControllerTestSuite) SetupTest() {
+	suite.orderUseCase = new(MockOrderUseCase)
+	suite.controller = NewOrderController(suite.orderUseCase)
+	gin.SetMode(gin.TestMode)
+	suite.router = gin.Default()
+}
+
+func TestOrderControllerTestSuite(t *testing.T) {
+	suite.Run(t, new(OrderControllerTestSuite))
+}
+
+func (suite *OrderControllerTestSuite) TestPurchaseBundle_Success() {
+	// Setup
+	expectedOrder := &order.Order{ID: "order123"}
+	expectedPayment := &payment.Payment{ID: "payment123"}
+	expectedWarehouseItem := &warehouse.WarehouseItem{ID: "warehouse123"}
+
+	suite.orderUseCase.On("PurchaseBundle", mock.Anything, "bundle123", "reseller123").
+		Return(expectedOrder, expectedPayment, expectedWarehouseItem, nil)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", "reseller123")
+
+	body, _ := json.Marshal(gin.H{"bundle_id": "bundle123"})
+	c.Request = httptest.NewRequest("POST", "/purchase", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	// Execute
+	suite.controller.PurchaseBundle(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.orderUseCase.AssertExpectations(suite.T())
+}
+
+func (suite *OrderControllerTestSuite) TestPurchaseBundle_InvalidPayload() {
+	// Setup
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	body, _ := json.Marshal(gin.H{})
+	c.Request = httptest.NewRequest("POST", "/purchase", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	// Execute
+	suite.controller.PurchaseBundle(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+}
+
+func (suite *OrderControllerTestSuite) TestPurchaseBundle_InvalidUserID() {
+	// Setup
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	body, _ := json.Marshal(gin.H{"bundle_id": "bundle123"})
+	c.Request = httptest.NewRequest("POST", "/purchase", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	// Execute
+	suite.controller.PurchaseBundle(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+}
+
+func (suite *OrderControllerTestSuite) TestPurchaseBundle_UseCaseError() {
+	// Setup
+	suite.orderUseCase.On("PurchaseBundle", mock.Anything, "bundle123", "reseller123").
+		Return(nil, nil, nil, errors.New("use case error"))
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", "reseller123")
+
+	body, _ := json.Marshal(gin.H{"bundle_id": "bundle123"})
+	c.Request = httptest.NewRequest("POST", "/purchase", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	// Execute
+	suite.controller.PurchaseBundle(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusInternalServerError, w.Code)
+	suite.orderUseCase.AssertExpectations(suite.T())
+}
+
+func (suite *OrderControllerTestSuite) TestGetOrderByID_Success() {
+	// Setup
+	expectedOrder := &order.Order{ID: "order123"}
+	suite.orderUseCase.On("GetOrderByID", mock.Anything, "order123").
+		Return(expectedOrder, nil)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{gin.Param{Key: "id", Value: "order123"}}
+
+	// Execute
+	suite.controller.GetOrderByID(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.orderUseCase.AssertExpectations(suite.T())
+}
+
+func (suite *OrderControllerTestSuite) TestGetOrderByID_MissingID() {
+	// Setup
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	// Execute
+	suite.controller.GetOrderByID(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+}
+
+func (suite *OrderControllerTestSuite) TestGetOrderByID_UseCaseError() {
+	// Setup
+	suite.orderUseCase.On("GetOrderByID", mock.Anything, "order123").
+		Return(nil, errors.New("use case error"))
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{gin.Param{Key: "id", Value: "order123"}}
+
+	// Execute
+	suite.controller.GetOrderByID(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusInternalServerError, w.Code)
+	suite.orderUseCase.AssertExpectations(suite.T())
+}

--- a/internal/interface/controllers/product_controller_test.go
+++ b/internal/interface/controllers/product_controller_test.go
@@ -1,0 +1,422 @@
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/bundle"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/product"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/warehouse"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+var (
+	ErrProductNotFound = errors.New("product not found")
+)
+
+type ProductControllerTestSuite struct {
+	suite.Suite
+	productUseCase *MockProductUseCase
+	trustUseCase   *MockTrustUseCase
+	bundleUseCase  *MockBundleUseCase
+	warehouseRepo  *MockWarehouseRepo
+	controller     *ProductController
+	router         *gin.Engine
+}
+
+type MockProductUseCase struct {
+	mock.Mock
+}
+
+func (m *MockProductUseCase) AddProduct(ctx context.Context, p *product.Product) error {
+	args := m.Called(ctx, p)
+	return args.Error(0)
+}
+
+func (m *MockProductUseCase) GetProductByID(ctx context.Context, id string) (*product.Product, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*product.Product), args.Error(1)
+}
+
+func (m *MockProductUseCase) ListAvailableProducts(ctx context.Context, page, limit int) ([]*product.Product, error) {
+	args := m.Called(ctx, page, limit)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*product.Product), args.Error(1)
+}
+
+func (m *MockProductUseCase) ListProductsByReseller(ctx context.Context, resellerID string, page, limit int) ([]*product.Product, error) {
+	args := m.Called(ctx, resellerID, page, limit)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*product.Product), args.Error(1)
+}
+
+func (m *MockProductUseCase) UpdateProduct(ctx context.Context, id string, updates map[string]interface{}) error {
+	args := m.Called(ctx, id, updates)
+	return args.Error(0)
+}
+
+func (m *MockProductUseCase) DeleteProduct(ctx context.Context, id string) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+type MockTrustUseCase struct {
+	mock.Mock
+}
+
+func (m *MockTrustUseCase) UpdateSupplierTrustScoreOnNewRating(ctx context.Context, supplierID string, declaredRating, actualRating float64) error {
+	args := m.Called(ctx, supplierID, declaredRating, actualRating)
+	return args.Error(0)
+}
+
+type MockBundleUseCase struct {
+	mock.Mock
+}
+
+func (m *MockBundleUseCase) CreateBundle(ctx context.Context, supplierID string, bundle *bundle.Bundle) error {
+	args := m.Called(ctx, supplierID, bundle)
+	return args.Error(0)
+}
+
+func (m *MockBundleUseCase) DeleteBundle(ctx context.Context, supplierID, bundleID string) error {
+	args := m.Called(ctx, supplierID, bundleID)
+	return args.Error(0)
+}
+
+func (m *MockBundleUseCase) GetBundleByID(ctx context.Context, supplierID, bundleID string) (*bundle.Bundle, error) {
+	args := m.Called(ctx, supplierID, bundleID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*bundle.Bundle), args.Error(1)
+}
+
+func (m *MockBundleUseCase) GetBundlePublicByID(ctx context.Context, id string) (*bundle.Bundle, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*bundle.Bundle), args.Error(1)
+}
+
+func (m *MockBundleUseCase) ListAvailableBundles(ctx context.Context) ([]*bundle.Bundle, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*bundle.Bundle), args.Error(1)
+}
+
+func (m *MockBundleUseCase) ListBundles(ctx context.Context, supplierID string) ([]*bundle.Bundle, error) {
+	args := m.Called(ctx, supplierID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*bundle.Bundle), args.Error(1)
+}
+
+func (m *MockBundleUseCase) UpdateBundle(ctx context.Context, supplierID string, bundleID string, updates map[string]interface{}) error {
+	args := m.Called(ctx, supplierID, bundleID, updates)
+	return args.Error(0)
+}
+
+func (m *MockBundleUseCase) DecreaseRemainingItemCount(ctx context.Context, id string) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+type MockWarehouseRepo struct {
+	mock.Mock
+}
+
+func (m *MockWarehouseRepo) HasResellerReceivedBundle(ctx context.Context, resellerID, bundleID string) (bool, error) {
+	args := m.Called(ctx, resellerID, bundleID)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockWarehouseRepo) AddItem(ctx context.Context, item *warehouse.WarehouseItem) error {
+	args := m.Called(ctx, item)
+	return args.Error(0)
+}
+
+func (m *MockWarehouseRepo) DeleteItem(ctx context.Context, itemID string) error {
+	args := m.Called(ctx, itemID)
+	return args.Error(0)
+}
+
+func (m *MockWarehouseRepo) GetItemsByBundle(ctx context.Context, bundleID string) ([]*warehouse.WarehouseItem, error) {
+	args := m.Called(ctx, bundleID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*warehouse.WarehouseItem), args.Error(1)
+}
+
+func (m *MockWarehouseRepo) GetItemsByReseller(ctx context.Context, resellerID string) ([]*warehouse.WarehouseItem, error) {
+	args := m.Called(ctx, resellerID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*warehouse.WarehouseItem), args.Error(1)
+}
+
+func (m *MockWarehouseRepo) MarkItemAsListed(ctx context.Context, itemID string) error {
+	args := m.Called(ctx, itemID)
+	return args.Error(0)
+}
+
+func (m *MockWarehouseRepo) MarkItemAsSkipped(ctx context.Context, itemID string) error {
+	args := m.Called(ctx, itemID)
+	return args.Error(0)
+}
+
+func (suite *ProductControllerTestSuite) SetupTest() {
+	suite.productUseCase = new(MockProductUseCase)
+	suite.trustUseCase = new(MockTrustUseCase)
+	suite.bundleUseCase = new(MockBundleUseCase)
+	suite.warehouseRepo = new(MockWarehouseRepo)
+	suite.controller = NewProductController(
+		suite.productUseCase,
+		suite.trustUseCase,
+		suite.bundleUseCase,
+		suite.warehouseRepo,
+	)
+	gin.SetMode(gin.TestMode)
+	suite.router = gin.Default()
+}
+
+func TestProductControllerTestSuite(t *testing.T) {
+	suite.Run(t, new(ProductControllerTestSuite))
+}
+
+func (suite *ProductControllerTestSuite) TestCreate_Success() {
+	// Setup
+	userID := primitive.NewObjectID()
+	product := &product.Product{
+		BundleID: "bundle123",
+		Rating:   4.5,
+	}
+	bundle := &bundle.Bundle{
+		SupplierID:         "supplier123",
+		DeclaredRating:     4.0,
+		RemainingItemCount: 5,
+	}
+
+	suite.warehouseRepo.On("HasResellerReceivedBundle", mock.Anything, userID.Hex(), product.BundleID).
+		Return(true, nil)
+	suite.bundleUseCase.On("GetBundlePublicByID", mock.Anything, product.BundleID).
+		Return(bundle, nil)
+	suite.productUseCase.On("AddProduct", mock.Anything, mock.Anything).
+		Return(nil)
+	suite.bundleUseCase.On("DecreaseRemainingItemCount", mock.Anything, product.BundleID).
+		Return(nil)
+	suite.trustUseCase.On("UpdateSupplierTrustScoreOnNewRating", mock.Anything, bundle.SupplierID, float64(bundle.DeclaredRating), product.Rating).
+		Return(nil).Run(func(args mock.Arguments) {
+		// Add a small delay to allow the goroutine to complete
+		time.Sleep(100 * time.Millisecond)
+	})
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", userID.Hex())
+
+	body, _ := json.Marshal(product)
+	req := httptest.NewRequest("POST", "/products", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	// Execute
+	suite.controller.Create(c)
+
+	// Add a small delay to allow the goroutine to complete
+	time.Sleep(200 * time.Millisecond)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusCreated, w.Code)
+	suite.warehouseRepo.AssertExpectations(suite.T())
+	suite.bundleUseCase.AssertExpectations(suite.T())
+	suite.productUseCase.AssertExpectations(suite.T())
+	suite.trustUseCase.AssertExpectations(suite.T())
+}
+
+func (suite *ProductControllerTestSuite) TestCreate_InvalidPayload() {
+	// Setup
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	body, _ := json.Marshal("invalid")
+	c.Request = httptest.NewRequest("POST", "/products", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	// Execute
+	suite.controller.Create(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+}
+
+func (suite *ProductControllerTestSuite) TestCreate_Unauthorized() {
+	// Setup
+	product := &product.Product{
+		BundleID: "bundle123",
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	body, _ := json.Marshal(product)
+	c.Request = httptest.NewRequest("POST", "/products", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	// Execute
+	suite.controller.Create(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+}
+
+func (suite *ProductControllerTestSuite) TestGetByID_Success() {
+	// Setup
+	expectedProduct := &product.Product{ID: "product123"}
+	suite.productUseCase.On("GetProductByID", mock.Anything, "product123").
+		Return(expectedProduct, nil)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{gin.Param{Key: "id", Value: "product123"}}
+	c.Request = httptest.NewRequest("GET", "/products/product123", nil)
+
+	// Execute
+	suite.controller.GetByID(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.productUseCase.AssertExpectations(suite.T())
+}
+
+func (suite *ProductControllerTestSuite) TestGetByID_NotFound() {
+	// Setup
+	suite.productUseCase.On("GetProductByID", mock.Anything, "product123").
+		Return(nil, ErrProductNotFound)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{gin.Param{Key: "id", Value: "product123"}}
+	c.Request = httptest.NewRequest("GET", "/products/product123", nil)
+
+	// Execute
+	suite.controller.GetByID(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusNotFound, w.Code)
+	suite.productUseCase.AssertExpectations(suite.T())
+}
+
+func (suite *ProductControllerTestSuite) TestListAvailable_Success() {
+	// Setup
+	expectedProducts := []*product.Product{
+		{ID: "product1"},
+		{ID: "product2"},
+	}
+	suite.productUseCase.On("ListAvailableProducts", mock.Anything, 1, 10).
+		Return(expectedProducts, nil)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/products?page=1&limit=10", nil)
+
+	// Execute
+	suite.controller.ListAvailable(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.productUseCase.AssertExpectations(suite.T())
+}
+
+func (suite *ProductControllerTestSuite) TestListByReseller_Success() {
+	// Setup
+	expectedProducts := []*product.Product{
+		{ID: "product1"},
+		{ID: "product2"},
+	}
+	suite.productUseCase.On("ListProductsByReseller", mock.Anything, "reseller123", 1, 10).
+		Return(expectedProducts, nil)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{gin.Param{Key: "id", Value: "reseller123"}}
+	c.Request = httptest.NewRequest("GET", "/resellers/reseller123/products?page=1&limit=10", nil)
+
+	// Execute
+	suite.controller.ListByReseller(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.productUseCase.AssertExpectations(suite.T())
+}
+
+func (suite *ProductControllerTestSuite) TestUpdate_Success() {
+	// Setup
+	updates := map[string]interface{}{
+		"name": "Updated Product",
+	}
+	suite.productUseCase.On("UpdateProduct", mock.Anything, "product123", updates).
+		Return(nil)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{gin.Param{Key: "id", Value: "product123"}}
+
+	body, _ := json.Marshal(updates)
+	c.Request = httptest.NewRequest("PUT", "/products/product123", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	// Execute
+	suite.controller.Update(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.productUseCase.AssertExpectations(suite.T())
+}
+
+func (suite *ProductControllerTestSuite) TestDelete_Success() {
+	// Setup
+	suite.productUseCase.On("DeleteProduct", mock.Anything, "product123").
+		Return(nil)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{gin.Param{Key: "id", Value: "product123"}}
+	c.Request = httptest.NewRequest("DELETE", "/products/product123", nil)
+
+	// Execute
+	suite.controller.Delete(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.productUseCase.AssertExpectations(suite.T())
+}

--- a/internal/interface/controllers/review_controller_test.go
+++ b/internal/interface/controllers/review_controller_test.go
@@ -1,0 +1,155 @@
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"errors"
+
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/review"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/models"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type MockReviewUsecase struct {
+	mock.Mock
+}
+
+func (m *MockReviewUsecase) SubmitReview(ctx context.Context, r *review.Review) error {
+	args := m.Called(ctx, r)
+	return args.Error(0)
+}
+
+type ReviewControllerTestSuite struct {
+	suite.Suite
+	usecase    *MockReviewUsecase
+	controller *ReviewController
+	router     *gin.Engine
+}
+
+func (suite *ReviewControllerTestSuite) SetupTest() {
+	suite.usecase = new(MockReviewUsecase)
+	suite.controller = NewReviewController(suite.usecase)
+	gin.SetMode(gin.TestMode)
+	suite.router = gin.Default()
+}
+
+func TestReviewControllerTestSuite(t *testing.T) {
+	suite.Run(t, new(ReviewControllerTestSuite))
+}
+
+func (suite *ReviewControllerTestSuite) TestSubmitReview_Success() {
+	// Setup
+	req := models.CreateReviewRequest{
+		OrderID:   "order123",
+		ProductID: "product123",
+		Rating:    4,
+		Comment:   "Great product!",
+	}
+
+	suite.usecase.On("SubmitReview", mock.Anything, mock.Anything).
+		Return(nil)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", "user123")
+
+	body, _ := json.Marshal(req)
+	request := httptest.NewRequest("POST", "/reviews", bytes.NewBuffer(body))
+	request.Header.Set("Content-Type", "application/json")
+	c.Request = request
+
+	// Execute
+	suite.controller.SubmitReview(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusCreated, w.Code)
+	suite.usecase.AssertExpectations(suite.T())
+}
+
+func (suite *ReviewControllerTestSuite) TestSubmitReview_InvalidPayload() {
+	// Setup
+	invalidPayload := "invalid json"
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", "user123")
+
+	request := httptest.NewRequest("POST", "/reviews", bytes.NewBufferString(invalidPayload))
+	request.Header.Set("Content-Type", "application/json")
+	c.Request = request
+
+	// Execute
+	suite.controller.SubmitReview(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+	suite.usecase.AssertNotCalled(suite.T(), "SubmitReview")
+}
+
+func (suite *ReviewControllerTestSuite) TestSubmitReview_Unauthorized() {
+	// Setup
+	req := models.CreateReviewRequest{
+		OrderID:   "order123",
+		ProductID: "product123",
+		Rating:    4,
+		Comment:   "Great product!",
+	}
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	// Note: No userID set
+
+	body, _ := json.Marshal(req)
+	request := httptest.NewRequest("POST", "/reviews", bytes.NewBuffer(body))
+	request.Header.Set("Content-Type", "application/json")
+	c.Request = request
+
+	// Execute
+	suite.controller.SubmitReview(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+	suite.usecase.AssertNotCalled(suite.T(), "SubmitReview")
+}
+
+func (suite *ReviewControllerTestSuite) TestSubmitReview_UseCaseError() {
+	// Setup
+	req := models.CreateReviewRequest{
+		OrderID:   "order123",
+		ProductID: "product123",
+		Rating:    4,
+		Comment:   "Great product!",
+	}
+
+	expectedError := errors.New("review already exists")
+	suite.usecase.On("SubmitReview", mock.Anything, mock.Anything).
+		Return(expectedError)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", "user123")
+
+	body, _ := json.Marshal(req)
+	request := httptest.NewRequest("POST", "/reviews", bytes.NewBuffer(body))
+	request.Header.Set("Content-Type", "application/json")
+	c.Request = request
+
+	// Execute
+	suite.controller.SubmitReview(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+	suite.usecase.AssertExpectations(suite.T())
+}

--- a/internal/interface/controllers/supplier_controller_test.go
+++ b/internal/interface/controllers/supplier_controller_test.go
@@ -1,0 +1,242 @@
+package controllers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/bundle"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/order"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/payment"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/warehouse"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type MockOrderUsecase struct {
+	mock.Mock
+}
+
+func (m *MockOrderUsecase) PurchaseBundle(ctx context.Context, bundleID, resellerID string) (*order.Order, *payment.Payment, *warehouse.WarehouseItem, error) {
+	args := m.Called(ctx, bundleID, resellerID)
+	if args.Get(0) == nil {
+		return nil, nil, nil, args.Error(3)
+	}
+	return args.Get(0).(*order.Order), args.Get(1).(*payment.Payment), args.Get(2).(*warehouse.WarehouseItem), args.Error(3)
+}
+
+func (m *MockOrderUsecase) GetDashboardMetrics(ctx context.Context, supplierID string) (*order.DashboardMetrics, error) {
+	args := m.Called(ctx, supplierID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*order.DashboardMetrics), args.Error(1)
+}
+
+func (m *MockOrderUsecase) GetOrderByID(ctx context.Context, orderID string) (*order.Order, error) {
+	args := m.Called(ctx, orderID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*order.Order), args.Error(1)
+}
+
+func (m *MockOrderUsecase) GetSoldBundleHistory(ctx context.Context, supplierID string) ([]*order.Order, error) {
+	args := m.Called(ctx, supplierID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*order.Order), args.Error(1)
+}
+
+type SupplierControllerTestSuite struct {
+	suite.Suite
+	usecase    *MockOrderUsecase
+	controller *SupplierController
+	router     *gin.Engine
+}
+
+func (suite *SupplierControllerTestSuite) SetupTest() {
+	suite.usecase = new(MockOrderUsecase)
+	suite.controller = NewSupplierController(suite.usecase)
+	gin.SetMode(gin.TestMode)
+	suite.router = gin.Default()
+}
+
+func TestSupplierControllerTestSuite(t *testing.T) {
+	suite.Run(t, new(SupplierControllerTestSuite))
+}
+
+func (suite *SupplierControllerTestSuite) TestGetDashboardMetrics_Success() {
+	// Setup
+	expectedMetrics := &order.DashboardMetrics{
+		TotalSales: 1000.0,
+		ActiveBundles: []*bundle.Bundle{
+			{
+				ID: "bundle1",
+			},
+		},
+		PerformanceMetrics: order.PerformanceMetrics{
+			TotalBundlesListed: 10,
+			ActiveCount:        5,
+			SoldCount:          5,
+		},
+	}
+
+	suite.usecase.On("GetDashboardMetrics", mock.Anything, "supplier123").
+		Return(expectedMetrics, nil)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", "supplier123")
+	c.Request = httptest.NewRequest("GET", "/supplier/dashboard", nil)
+
+	// Execute
+	suite.controller.GetDashboardMetrics(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.usecase.AssertExpectations(suite.T())
+}
+
+func (suite *SupplierControllerTestSuite) TestGetDashboardMetrics_Unauthorized() {
+	// Setup
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	// Note: No userID set
+	c.Request = httptest.NewRequest("GET", "/supplier/dashboard", nil)
+
+	// Execute
+	suite.controller.GetDashboardMetrics(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+	suite.usecase.AssertNotCalled(suite.T(), "GetDashboardMetrics")
+}
+
+func (suite *SupplierControllerTestSuite) TestGetDashboardMetrics_InvalidUserID() {
+	// Setup
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", 123) // Invalid type
+	c.Request = httptest.NewRequest("GET", "/supplier/dashboard", nil)
+
+	// Execute
+	suite.controller.GetDashboardMetrics(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+	suite.usecase.AssertNotCalled(suite.T(), "GetDashboardMetrics")
+}
+
+func (suite *SupplierControllerTestSuite) TestGetDashboardMetrics_UseCaseError() {
+	// Setup
+	suite.usecase.On("GetDashboardMetrics", mock.Anything, "supplier123").
+		Return(nil, assert.AnError)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", "supplier123")
+	c.Request = httptest.NewRequest("GET", "/supplier/dashboard", nil)
+
+	// Execute
+	suite.controller.GetDashboardMetrics(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusInternalServerError, w.Code)
+	suite.usecase.AssertExpectations(suite.T())
+}
+
+func (suite *SupplierControllerTestSuite) TestListSoldBundles_Success() {
+	// Setup
+	expectedOrders := []*order.Order{
+		{
+			ID:         "order1",
+			ResellerID: "reseller1",
+			SupplierID: "supplier123",
+			BundleID:   "bundle1",
+			Status:     order.OrderStatusCompleted,
+		},
+		{
+			ID:         "order2",
+			ResellerID: "reseller2",
+			SupplierID: "supplier123",
+			BundleID:   "bundle2",
+			Status:     order.OrderStatusCompleted,
+		},
+	}
+
+	suite.usecase.On("GetSoldBundleHistory", mock.Anything, "supplier123").
+		Return(expectedOrders, nil)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", "supplier123")
+	c.Request = httptest.NewRequest("GET", "/supplier/bundles", nil)
+
+	// Execute
+	suite.controller.ListSoldBundles(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.usecase.AssertExpectations(suite.T())
+}
+
+func (suite *SupplierControllerTestSuite) TestListSoldBundles_Unauthorized() {
+	// Setup
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	// Note: No userID set
+	c.Request = httptest.NewRequest("GET", "/supplier/bundles", nil)
+
+	// Execute
+	suite.controller.ListSoldBundles(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+	suite.usecase.AssertNotCalled(suite.T(), "GetSoldBundleHistory")
+}
+
+func (suite *SupplierControllerTestSuite) TestListSoldBundles_InvalidUserID() {
+	// Setup
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", 123) // Invalid type
+	c.Request = httptest.NewRequest("GET", "/supplier/bundles", nil)
+
+	// Execute
+	suite.controller.ListSoldBundles(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+	suite.usecase.AssertNotCalled(suite.T(), "GetSoldBundleHistory")
+}
+
+func (suite *SupplierControllerTestSuite) TestListSoldBundles_UseCaseError() {
+	// Setup
+	suite.usecase.On("GetSoldBundleHistory", mock.Anything, "supplier123").
+		Return(nil, assert.AnError)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", "supplier123")
+	c.Request = httptest.NewRequest("GET", "/supplier/bundles", nil)
+
+	// Execute
+	suite.controller.ListSoldBundles(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusInternalServerError, w.Code)
+	suite.usecase.AssertExpectations(suite.T())
+}

--- a/internal/interface/controllers/warehouse_controller_test.go
+++ b/internal/interface/controllers/warehouse_controller_test.go
@@ -1,0 +1,149 @@
+package controllers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/warehouse"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type MockWarehouseUsecase struct {
+	mock.Mock
+}
+
+func (m *MockWarehouseUsecase) GetWarehouseItems(ctx context.Context, resellerID string) ([]*warehouse.WarehouseItem, error) {
+	args := m.Called(ctx, resellerID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*warehouse.WarehouseItem), args.Error(1)
+}
+
+type WarehouseControllerTestSuite struct {
+	suite.Suite
+	usecase    *MockWarehouseUsecase
+	controller *WarehouseController
+	router     *gin.Engine
+}
+
+func (suite *WarehouseControllerTestSuite) SetupTest() {
+	suite.usecase = new(MockWarehouseUsecase)
+	suite.controller = NewWarehouseController(suite.usecase)
+	gin.SetMode(gin.TestMode)
+	suite.router = gin.Default()
+}
+
+func TestWarehouseControllerTestSuite(t *testing.T) {
+	suite.Run(t, new(WarehouseControllerTestSuite))
+}
+
+func (suite *WarehouseControllerTestSuite) TestGetWarehouseItems_Success() {
+	// Setup
+	expectedItems := []*warehouse.WarehouseItem{
+		{
+			ID:         "item1",
+			ResellerID: "reseller123",
+			BundleID:   "bundle1",
+			ProductID:  "product1",
+			Status:     "listed",
+			CreatedAt:  "2024-01-01",
+		},
+		{
+			ID:         "item2",
+			ResellerID: "reseller123",
+			BundleID:   "bundle2",
+			ProductID:  "product2",
+			Status:     "pending",
+			CreatedAt:  "2024-01-02",
+		},
+	}
+
+	suite.usecase.On("GetWarehouseItems", mock.Anything, "reseller123").
+		Return(expectedItems, nil)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", "reseller123")
+	c.Request = httptest.NewRequest("GET", "/warehouse/items", nil)
+
+	// Execute
+	suite.controller.GetWarehouseItems(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.usecase.AssertExpectations(suite.T())
+}
+
+func (suite *WarehouseControllerTestSuite) TestGetWarehouseItems_Unauthorized() {
+	// Setup
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	// Note: No userID set
+	c.Request = httptest.NewRequest("GET", "/warehouse/items", nil)
+
+	// Execute
+	suite.controller.GetWarehouseItems(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+	suite.usecase.AssertNotCalled(suite.T(), "GetWarehouseItems")
+}
+
+func (suite *WarehouseControllerTestSuite) TestGetWarehouseItems_InvalidUserID() {
+	// Setup
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", 123) // Invalid type
+	c.Request = httptest.NewRequest("GET", "/warehouse/items", nil)
+
+	// Execute
+	suite.controller.GetWarehouseItems(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+	suite.usecase.AssertNotCalled(suite.T(), "GetWarehouseItems")
+}
+
+func (suite *WarehouseControllerTestSuite) TestGetWarehouseItems_EmptyUserID() {
+	// Setup
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", "") // Empty string
+	c.Request = httptest.NewRequest("GET", "/warehouse/items", nil)
+
+	// Execute
+	suite.controller.GetWarehouseItems(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
+	suite.usecase.AssertNotCalled(suite.T(), "GetWarehouseItems")
+}
+
+func (suite *WarehouseControllerTestSuite) TestGetWarehouseItems_UseCaseError() {
+	// Setup
+	suite.usecase.On("GetWarehouseItems", mock.Anything, "reseller123").
+		Return(nil, assert.AnError)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("userID", "reseller123")
+	c.Request = httptest.NewRequest("GET", "/warehouse/items", nil)
+
+	// Execute
+	suite.controller.GetWarehouseItems(c)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusInternalServerError, w.Code)
+	suite.usecase.AssertExpectations(suite.T())
+}


### PR DESCRIPTION
# Test Coverage Improvements for Controllers

## Description
This PR adds comprehensive test coverage for the controller layer. The changes include:

- Implemented test cases for all controller methods
- Added proper error handling test cases
- Improved existing test coverage to 76.2% overall

## Test Coverage
- Overall coverage: 76.2%
- All test suites passing:
  - AdminController
  - AuthController
  - BundleController
  - CartItemController
  - ConsumerController
  - OrderController
  - ProductController
  - ReviewController
  - SupplierController
  - WarehouseController

## Testing
To run the tests:
```bash
go test -cover ./internal/interface/controllers/...
```

## Checklist
- [x] All tests pass
- [x] Code follows project style guidelines
- [x] Tests cover all edge cases
- [x] Documentation is up to date
- [x] No breaking changes introduced

## Notes
- The test suite uses testify's mock, assert, and suite packages
- All controllers now have proper error handling test cases
- Test coverage has been significantly improved