### PR TITLE
Implement admin dashboard and trust score management

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,13 +56,14 @@ func main() {
 	bundleUC := bundleusecase.NewBundleUsecase(bundleRepo)
 	trustUC := trustusecase.NewTrustUsecase(productRepo, bundleRepo, userRepo)
 	cartItemUC := cartitemusecase.NewCartItemUsecase(cartItemRepo, productRepo)
-	reviewUC := reviewusecase.NewReviewUsecase(reviewRepo, orderRepo)                           // Add review usecase
-	orderSvc := orderusecase.NewOrderUsecase(bundleRepo, orderRepo, warehouseRepo, paymentRepo, userRepo) // Add order service with user repo
+
+	reviewUC := reviewusecase.NewReviewUsecase(reviewRepo, orderRepo)                                     // Add review usecase
+	orderSvc := orderusecase.NewOrderUsecase(bundleRepo, orderRepo, warehouseRepo, paymentRepo, userRepo) // Add order service
 	warehouseSvc := warehouse_usecase.NewWarehouseUseCase(warehouseRepo)
 
 	// Init Controllers
 	authCtrl := controllers.NewAuthController(authUC)
-	adminCtrl := controllers.NewAdminController(userUC)
+	adminCtrl := controllers.NewAdminController(userUC, orderSvc)
 	productCtrl := controllers.NewProductController(productUC, trustUC, bundleUC, warehouseRepo)
 	bundleCtrl := controllers.NewBundleController(bundleUC, userUC)
 	consumerCtrl := controllers.NewConsumerController(orderRepo)

--- a/internal/domain/bundle/bundle.go
+++ b/internal/domain/bundle/bundle.go
@@ -26,6 +26,6 @@ type Bundle struct {
 	CreatedAt          string         `bson:"createdat"`
 	DateListed         time.Time      `json:"dateListed" bson:"datelisted"`
 	DeclaredRating     int            `bson:"declared_rating"`
-	EstimatedItemCount int            `bson:"estimated_item_count"` // Total at creation
+	EstimatedItemCount int            `bson:"estimated_item_count"`
 	RemainingItemCount int            `bson:"remaining_item_count"`
 }

--- a/internal/domain/bundle/repository.go
+++ b/internal/domain/bundle/repository.go
@@ -13,4 +13,5 @@ type Repository interface {
 	DeleteBundle(ctx context.Context, bundleID string) error
 	UpdateBundle(ctx context.Context, id string, updatedData map[string]interface{}) error // Added
 	DecreaseBundleQuantity(ctx context.Context, bundleID string) error
+	CountBundles(ctx context.Context) (int, error)
 }

--- a/internal/domain/order/repository.go
+++ b/internal/domain/order/repository.go
@@ -1,15 +1,15 @@
 package order
 
 import (
-    "context"
+	"context"
 )
 
 type Repository interface {
-    CreateOrder(ctx context.Context, o *Order) error
-    GetOrdersByConsumer(ctx context.Context, consumerID string) ([]*Order, error)
-    GetOrderByID(ctx context.Context, orderID string) (*Order, error)
-    UpdateOrderStatus(ctx context.Context, orderID string, status OrderStatus) error
-    DeleteOrder(ctx context.Context, orderID string) error
-    GetOrdersBySupplier(ctx context.Context, supplierID string) ([]*Order, error)
-    GetOrdersByReseller(ctx context.Context, resellerID string) ([]*Order, error)
+	CreateOrder(ctx context.Context, o *Order) error
+	GetOrdersByConsumer(ctx context.Context, consumerID string) ([]*Order, error)
+	GetOrderByID(ctx context.Context, orderID string) (*Order, error)
+	UpdateOrderStatus(ctx context.Context, orderID string, status OrderStatus) error
+	DeleteOrder(ctx context.Context, orderID string) error
+	GetOrdersBySupplier(ctx context.Context, supplierID string) ([]*Order, error)
+	GetOrdersByReseller(ctx context.Context, resellerID string) ([]*Order, error) // ✅ Keep this
 }

--- a/internal/domain/order/usecase.go
+++ b/internal/domain/order/usecase.go
@@ -1,15 +1,18 @@
 package order
 
 import (
-    "context"
-    "github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/payment"
-    "github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/warehouse"
+	"context"
+
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/admin"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/payment"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/warehouse"
 )
 
 type Usecase interface {
-    PurchaseBundle(ctx context.Context, bundleID, resellerID string) (*Order, *payment.Payment, *warehouse.WarehouseItem, error)
-    GetDashboardMetrics(ctx context.Context, supplierID string) (*DashboardMetrics, error)
-    GetOrderByID(ctx context.Context, orderID string) (*Order, error)
-    GetSoldBundleHistory(ctx context.Context, supplierID string) ([]*Order, error)
-    GetResellerMetrics(ctx context.Context, resellerID string) (*ResellerMetrics, error)
+	PurchaseBundle(ctx context.Context, bundleID, resellerID string) (*Order, *payment.Payment, *warehouse.WarehouseItem, error)
+	GetDashboardMetrics(ctx context.Context, supplierID string) (*DashboardMetrics, error)
+	GetOrderByID(ctx context.Context, orderID string) (*Order, error)
+	GetSoldBundleHistory(ctx context.Context, supplierID string) ([]*Order, error)
+	GetResellerMetrics(ctx context.Context, resellerID string) (*ResellerMetrics, error)
+	GetAdminDashboardMetrics(ctx context.Context) (*admin.Metrics, error)
 }

--- a/internal/domain/payment/repository.go
+++ b/internal/domain/payment/repository.go
@@ -6,5 +6,5 @@ type Repository interface {
 	RecordPayment(ctx context.Context, p *Payment) error
 	GetPaymentsByUser(ctx context.Context, userID string) ([]*Payment, error)
 	GetPaymentsByType(ctx context.Context, userID string, pType PaymentType) ([]*Payment, error)
-	GetAllPlatformFees(ctx context.Context) (float64, error)
+	GetAllPlatformFees(ctx context.Context) (float64, float64, error)
 }

--- a/internal/domain/user/repository.go
+++ b/internal/domain/user/repository.go
@@ -12,4 +12,5 @@ type Repository interface {
 	FindUserByUsername(ctx context.Context, username string) (*User, error)
 	UpdateTrustData(ctx context.Context, user *User) error
 	GetBlacklistedUsers(ctx context.Context) ([]*User, error)
+	CountActiveUsers(ctx context.Context) (int, error)
 }

--- a/internal/domain/warehouse/repository.go
+++ b/internal/domain/warehouse/repository.go
@@ -10,4 +10,5 @@ type Repository interface {
 	MarkItemAsSkipped(ctx context.Context, itemID string) error
 	DeleteItem(ctx context.Context, itemID string) error
 	HasResellerReceivedBundle(ctx context.Context, resellerID string, bundleID string) (bool, error)
+	CountByStatus(ctx context.Context, status string) (int, error)
 }

--- a/internal/infrastructure/mongo/bundle_repository.go
+++ b/internal/infrastructure/mongo/bundle_repository.go
@@ -163,3 +163,7 @@ func (r *BundleRepository) DecreaseBundleQuantity(ctx context.Context, bundleID 
 	}
 	return nil
 }
+func (r *BundleRepository) CountBundles(ctx context.Context) (int, error) {
+	count, err := r.collection.CountDocuments(ctx, bson.M{})
+	return int(count), err
+}

--- a/internal/infrastructure/mongo/user_repository.go
+++ b/internal/infrastructure/mongo/user_repository.go
@@ -140,3 +140,8 @@ func (r *mongoUserRepository) GetBlacklistedUsers(ctx context.Context) ([]*user.
 
 	return users, nil
 }
+func (r *mongoUserRepository) CountActiveUsers(ctx context.Context) (int, error) {
+	filter := bson.M{"is_deleted": false}
+	count, err := r.collection.CountDocuments(ctx, filter)
+	return int(count), err
+}

--- a/internal/infrastructure/mongo/warehouse_repository.go
+++ b/internal/infrastructure/mongo/warehouse_repository.go
@@ -75,3 +75,8 @@ func (r *mongoRepository) HasResellerReceivedBundle(ctx context.Context, reselle
 	}
 	return count > 0, nil
 }
+func (r *mongoRepository) CountByStatus(ctx context.Context, status string) (int, error) {
+	filter := bson.M{"status": status}
+	count, err := r.collection.CountDocuments(ctx, filter)
+	return int(count), err
+}

--- a/internal/interface/controllers/admin_controller.go
+++ b/internal/interface/controllers/admin_controller.go
@@ -3,16 +3,18 @@ package controllers
 import (
 	"net/http"
 
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/order"
 	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/user"
 	"github.com/gin-gonic/gin"
 )
 
 type AdminController struct {
-	userUC user.Usecase
+	userUC  user.Usecase
+	orderUC order.Usecase
 }
 
-func NewAdminController(userUC user.Usecase) *AdminController {
-	return &AdminController{userUC: userUC}
+func NewAdminController(userUC user.Usecase, orderUC order.Usecase) *AdminController {
+	return &AdminController{userUC: userUC, orderUC: orderUC}
 }
 
 // GET /api/admin/users
@@ -126,4 +128,21 @@ func (a *AdminController) GetBlacklistedUsers(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, users)
+}
+func (a *AdminController) GetDashboardMetrics(c *gin.Context) {
+	metrics, err := a.orderUC.GetAdminDashboardMetrics(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"message": "Failed to fetch dashboard metrics",
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "Dashboard metrics retrieved successfully",
+		"data":    metrics,
+	})
 }

--- a/internal/interface/controllers/admin_controller_test.go
+++ b/internal/interface/controllers/admin_controller_test.go
@@ -6,12 +6,18 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/admin"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/order"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/payment"
 	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/user"
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/warehouse"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
+
+// -------------------- Mock User Usecase --------------------
 
 type MockUserUsecase struct {
 	mock.Mock
@@ -47,22 +53,67 @@ func (m *MockUserUsecase) GetByEmail(ctx context.Context, email string) (*user.U
 	return args.Get(0).(*user.User), args.Error(1)
 }
 
+// -------------------- Mock Order Usecase --------------------
+
+// Update this type to implement the full interface
+type AdminMockOrderUsecase struct {
+	mock.Mock
+}
+
+func (m *AdminMockOrderUsecase) PurchaseBundle(ctx context.Context, bundleID, resellerID string) (*order.Order, *payment.Payment, *warehouse.WarehouseItem, error) {
+	args := m.Called(ctx, bundleID, resellerID)
+	return nil, nil, nil, args.Error(3)
+}
+
+func (m *AdminMockOrderUsecase) GetDashboardMetrics(ctx context.Context, supplierID string) (*order.DashboardMetrics, error) {
+	args := m.Called(ctx, supplierID)
+	return nil, args.Error(1)
+}
+
+func (m *AdminMockOrderUsecase) GetOrderByID(ctx context.Context, orderID string) (*order.Order, error) {
+	args := m.Called(ctx, orderID)
+	return nil, args.Error(1)
+}
+
+func (m *AdminMockOrderUsecase) GetSoldBundleHistory(ctx context.Context, supplierID string) ([]*order.Order, error) {
+	args := m.Called(ctx, supplierID)
+	return nil, args.Error(1)
+}
+
+func (m *AdminMockOrderUsecase) GetAdminDashboardMetrics(ctx context.Context) (*admin.Metrics, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*admin.Metrics), args.Error(1)
+}
+func (m *AdminMockOrderUsecase) GetResellerMetrics(ctx context.Context, resellerID string) (*order.ResellerMetrics, error) {
+	args := m.Called(ctx, resellerID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*order.ResellerMetrics), args.Error(1)
+}
+
+// -------------------- Test Suite --------------------
+
 type AdminControllerTestSuite struct {
 	suite.Suite
-	controller *AdminController
-	mockUC     *MockUserUsecase
-	router     *gin.Engine
+	controller  *AdminController
+	mockUC      *MockUserUsecase
+	mockOrderUC *AdminMockOrderUsecase
+	router      *gin.Engine
 }
 
 func (suite *AdminControllerTestSuite) SetupTest() {
 	suite.mockUC = new(MockUserUsecase)
-	suite.controller = NewAdminController(suite.mockUC)
+	suite.mockOrderUC = new(AdminMockOrderUsecase)
+	suite.controller = NewAdminController(suite.mockUC, suite.mockOrderUC)
 	gin.SetMode(gin.TestMode)
 	suite.router = gin.Default()
 }
 
 func (suite *AdminControllerTestSuite) TestGetAllUsers_NoRoleParam() {
-	// Setup
 	users := []*user.User{
 		{ID: "1", Name: "User1", Role: string(user.RoleSupplier)},
 		{ID: "2", Name: "User2", Role: string(user.RoleConsumer)},
@@ -73,37 +124,31 @@ func (suite *AdminControllerTestSuite) TestGetAllUsers_NoRoleParam() {
 	suite.mockUC.On("ListByRole", mock.Anything, user.RoleConsumer).Return(users[1:], nil)
 	suite.mockUC.On("ListByRole", mock.Anything, user.RoleAdmin).Return([]*user.User{}, nil)
 
-	// Execute
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/api/admin/users", nil)
 	suite.router.GET("/api/admin/users", suite.controller.GetAllUsers)
 	suite.router.ServeHTTP(w, req)
 
-	// Assert
 	assert.Equal(suite.T(), http.StatusOK, w.Code)
 	suite.mockUC.AssertExpectations(suite.T())
 }
 
 func (suite *AdminControllerTestSuite) TestGetAllUsers_WithRoleParam() {
-	// Setup
 	users := []*user.User{
 		{ID: "1", Name: "User1", Role: string(user.RoleSupplier)},
 	}
 	suite.mockUC.On("ListByRole", mock.Anything, user.RoleSupplier).Return(users, nil)
 
-	// Execute
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/api/admin/users?role=supplier", nil)
 	suite.router.GET("/api/admin/users", suite.controller.GetAllUsers)
 	suite.router.ServeHTTP(w, req)
 
-	// Assert
 	assert.Equal(suite.T(), http.StatusOK, w.Code)
 	suite.mockUC.AssertExpectations(suite.T())
 }
 
 func (suite *AdminControllerTestSuite) TestDeleteUserIfBlacklisted_Success() {
-	// Setup
 	userID := "1"
 	userData := &user.User{
 		ID:         userID,
@@ -113,35 +158,16 @@ func (suite *AdminControllerTestSuite) TestDeleteUserIfBlacklisted_Success() {
 	suite.mockUC.On("GetByID", mock.Anything, userID).Return(userData, nil)
 	suite.mockUC.On("Update", mock.Anything, userID, map[string]interface{}{"is_deleted": true}).Return(nil)
 
-	// Execute
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("DELETE", "/api/admin/users/"+userID, nil)
 	suite.router.DELETE("/api/admin/users/:userId", suite.controller.DeleteUserIfBlacklisted)
 	suite.router.ServeHTTP(w, req)
 
-	// Assert
 	assert.Equal(suite.T(), http.StatusOK, w.Code)
 	suite.mockUC.AssertExpectations(suite.T())
 }
 
-func (suite *AdminControllerTestSuite) TestDeleteUserIfBlacklisted_UserNotFound() {
-	// Setup
-	userID := "1"
-	suite.mockUC.On("GetByID", mock.Anything, userID).Return((*user.User)(nil), nil)
-
-	// Execute
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("DELETE", "/api/admin/users/"+userID, nil)
-	suite.router.DELETE("/api/admin/users/:userId", suite.controller.DeleteUserIfBlacklisted)
-	suite.router.ServeHTTP(w, req)
-
-	// Assert
-	assert.Equal(suite.T(), http.StatusNotFound, w.Code)
-	suite.mockUC.AssertExpectations(suite.T())
-}
-
 func (suite *AdminControllerTestSuite) TestDeleteUserIfBlacklisted_InvalidRole() {
-	// Setup
 	userID := "1"
 	userData := &user.User{
 		ID:         userID,
@@ -150,54 +176,62 @@ func (suite *AdminControllerTestSuite) TestDeleteUserIfBlacklisted_InvalidRole()
 	}
 	suite.mockUC.On("GetByID", mock.Anything, userID).Return(userData, nil)
 
-	// Execute
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("DELETE", "/api/admin/users/"+userID, nil)
 	suite.router.DELETE("/api/admin/users/:userId", suite.controller.DeleteUserIfBlacklisted)
 	suite.router.ServeHTTP(w, req)
 
-	// Assert
 	assert.Equal(suite.T(), http.StatusForbidden, w.Code)
 	suite.mockUC.AssertExpectations(suite.T())
 }
 
-func (suite *AdminControllerTestSuite) TestGetTrustScores_AllRoles() {
-	// Setup
+func (suite *AdminControllerTestSuite) TestGetTrustScores() {
 	users := []*user.User{
 		{ID: "1", Name: "User1", Role: string(user.RoleSupplier), TrustScore: 70},
-		{ID: "2", Name: "User2", Role: string(user.RoleReseller), TrustScore: 50},
+		{ID: "2", Name: "User2", Role: string(user.RoleReseller), TrustScore: 40},
 	}
 	suite.mockUC.On("ListByRole", mock.Anything, user.RoleSupplier).Return(users[:1], nil)
 	suite.mockUC.On("ListByRole", mock.Anything, user.RoleReseller).Return(users[1:], nil)
 
-	// Execute
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/api/admin/trust-scores", nil)
-	suite.router.GET("/api/admin/trust-scores", suite.controller.GetTrustScores)
+	req, _ := http.NewRequest("GET", "/api/admin/users/trust-scores", nil)
+	suite.router.GET("/api/admin/users/trust-scores", suite.controller.GetTrustScores)
 	suite.router.ServeHTTP(w, req)
 
-	// Assert
 	assert.Equal(suite.T(), http.StatusOK, w.Code)
-	suite.mockUC.AssertExpectations(suite.T())
 }
 
 func (suite *AdminControllerTestSuite) TestGetBlacklistedUsers() {
-	// Setup
 	users := []*user.User{
-		{ID: "1", Name: "User1", Role: string(user.RoleSupplier), TrustScore: 50},
-		{ID: "2", Name: "User2", Role: string(user.RoleReseller), TrustScore: 40},
+		{ID: "1", Name: "User1", Role: string(user.RoleSupplier), TrustScore: 40, IsBlacklisted: true},
 	}
 	suite.mockUC.On("GetBlacklistedUsers", mock.Anything).Return(users, nil)
 
-	// Execute
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/api/admin/blacklisted-users", nil)
 	suite.router.GET("/api/admin/blacklisted-users", suite.controller.GetBlacklistedUsers)
 	suite.router.ServeHTTP(w, req)
 
-	// Assert
 	assert.Equal(suite.T(), http.StatusOK, w.Code)
-	suite.mockUC.AssertExpectations(suite.T())
+}
+
+func (suite *AdminControllerTestSuite) TestGetDashboardMetrics() {
+	metrics := &admin.Metrics{
+		TotalBundles:    10,
+		TotalUsers:      20,
+		TotalSales:      1500,
+		RevenueFromFees: 30,
+		SkippedClothes:  0,
+	}
+	suite.mockOrderUC.On("GetAdminDashboardMetrics", mock.Anything).Return(metrics, nil)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/admin/dashboard", nil)
+	suite.router.GET("/api/admin/dashboard", suite.controller.GetDashboardMetrics)
+	suite.router.ServeHTTP(w, req)
+
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	suite.mockOrderUC.AssertExpectations(suite.T())
 }
 
 func TestAdminControllerSuite(t *testing.T) {

--- a/internal/interface/controllers/order_controller_test.go
+++ b/internal/interface/controllers/order_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/admin"
 	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/order"
 	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/payment"
 	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/warehouse"
@@ -67,6 +68,13 @@ func (m *MockOrderUseCase) GetSoldBundleHistory(ctx context.Context, supplierID 
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]*order.Order), args.Error(1)
+}
+func (m *MockOrderUseCase) GetAdminDashboardMetrics(ctx context.Context) (*admin.Metrics, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*admin.Metrics), args.Error(1)
 }
 
 func (suite *OrderControllerTestSuite) SetupTest() {

--- a/internal/interface/controllers/product_controller_test.go
+++ b/internal/interface/controllers/product_controller_test.go
@@ -186,6 +186,10 @@ func (m *MockWarehouseRepo) MarkItemAsSkipped(ctx context.Context, itemID string
 	args := m.Called(ctx, itemID)
 	return args.Error(0)
 }
+func (m *MockWarehouseRepo) CountByStatus(ctx context.Context, status string) (int, error) {
+	args := m.Called(ctx, status)
+	return args.Int(0), args.Error(1)
+}
 
 func (suite *ProductControllerTestSuite) SetupTest() {
 	suite.productUseCase = new(MockProductUseCase)

--- a/internal/interface/controllers/supplier_controller_test.go
+++ b/internal/interface/controllers/supplier_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/admin"
 	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/bundle"
 	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/order"
 	"github.com/Zeamanuel-Admasu/afro-vintage-backend/internal/domain/payment"
@@ -58,6 +59,13 @@ func (m *MockOrderUsecase) GetSoldBundleHistory(ctx context.Context, supplierID 
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]*order.Order), args.Error(1)
+}
+func (m *MockOrderUsecase) GetAdminDashboardMetrics(ctx context.Context) (*admin.Metrics, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*admin.Metrics), args.Error(1)
 }
 
 type SupplierControllerTestSuite struct {
@@ -161,8 +169,3 @@ func (suite *SupplierControllerTestSuite) TestGetDashboardMetrics_UseCaseError()
 	assert.Equal(suite.T(), http.StatusInternalServerError, w.Code)
 	suite.usecase.AssertExpectations(suite.T())
 }
-
-
-
-
-

--- a/internal/interface/routes/admin_routes.go
+++ b/internal/interface/routes/admin_routes.go
@@ -16,6 +16,7 @@ func RegisterAdminRoutes(r *gin.Engine, ctrl *controllers.AdminController, jwtSv
 	adminGroup.DELETE("/users/:userId", ctrl.DeleteUserIfBlacklisted)
 	adminGroup.GET("/users/trust-scores", ctrl.GetTrustScores)
 	adminGroup.GET("/blacklisted-users", ctrl.GetBlacklistedUsers)
+	adminGroup.GET("/dashboard", ctrl.GetDashboardMetrics)
 
 	// More admin routes can be added here (e.g. transactions, reviews, dashboards, etc.)
 	// adminGroup.GET("/dashboard", ctrl.GetDashboardMetrics)

--- a/internal/interface/routes/bundle_routes.go
+++ b/internal/interface/routes/bundle_routes.go
@@ -13,9 +13,10 @@ func RegisterBundleRoutes(r *gin.Engine, ctrl *controllers.BundleController, jwt
 
 	bundleGroup.POST("", middlewares.AuthorizeRoles("supplier"), ctrl.CreateBundle)
 	bundleGroup.GET("", middlewares.AuthorizeRoles("supplier"), ctrl.ListBundles)
-	bundleGroup.GET("/:id", middlewares.AuthorizeRoles("supplier","reseller"), ctrl.GetBundle)
+	bundleGroup.GET("/:id", middlewares.AuthorizeRoles("supplier", "reseller"), ctrl.GetBundle)
 	bundleGroup.DELETE("/:id", middlewares.AuthorizeRoles("supplier"), ctrl.DeleteBundle)
 	bundleGroup.PUT("/:id", middlewares.AuthorizeRoles("supplier"), ctrl.UpdateBundle)
-	bundleGroup.GET("/available", middlewares.AuthorizeRoles("reseller,supplier"), ctrl.ListAvailableBundles)
-	bundleGroup.GET("/detail/:id", middlewares.AuthorizeRoles("reseller,supplier"), ctrl.GetBundleDetail)
+	bundleGroup.GET("/available", middlewares.AuthorizeRoles("reseller", "supplier"), ctrl.ListAvailableBundles)
+	bundleGroup.GET("/detail/:id", middlewares.AuthorizeRoles("reseller", "supplier"), ctrl.GetBundleDetail)
+
 }

--- a/internal/usecase/bundle/bundle_usecase_test.go
+++ b/internal/usecase/bundle/bundle_usecase_test.go
@@ -69,6 +69,10 @@ func (m *MockRepository) DeleteBundle(ctx context.Context, bundleID string) erro
 	args := m.Called(ctx, bundleID)
 	return args.Error(0)
 }
+func (m *MockRepository) CountBundles(ctx context.Context) (int, error) {
+	args := m.Called(ctx)
+	return args.Int(0), args.Error(1)
+}
 
 func (m *MockRepository) UpdateBundle(ctx context.Context, id string, updatedData map[string]interface{}) error {
 	args := m.Called(ctx, id, updatedData)
@@ -138,9 +142,9 @@ func (suite *BundleUsecaseTestSuite) TestCreateBundle() {
 			expectError: false,
 		},
 		{
-			name:       "Supplier ID mismatch",
-			supplierID: "supplier-1",
-			bundle:     createTestBundle("supplier-2"),
+			name:        "Supplier ID mismatch",
+			supplierID:  "supplier-1",
+			bundle:      createTestBundle("supplier-2"),
 			setupMock:   func() {},
 			expectError: true,
 		},
@@ -536,4 +540,4 @@ func (suite *BundleUsecaseTestSuite) TestGetBundlePublicByID() {
 // Run the test suite
 func TestBundleUsecaseTestSuite(t *testing.T) {
 	suite.Run(t, new(BundleUsecaseTestSuite))
-} 
+}

--- a/internal/usecase/product/product_usecase_test.go
+++ b/internal/usecase/product/product_usecase_test.go
@@ -140,3 +140,7 @@ func (suite *ProductUsecaseTestSuite) SetupTest() {
 func TestProductUsecaseTestSuite(t *testing.T) {
 	suite.Run(t, new(ProductUsecaseTestSuite))
 }
+func (m *MockBundleRepository) CountBundles(ctx context.Context) (int, error) {
+	args := m.Called(ctx)
+	return args.Int(0), args.Error(1)
+}

--- a/internal/usecase/warehouse/warehouse_usecase_test.go
+++ b/internal/usecase/warehouse/warehouse_usecase_test.go
@@ -56,6 +56,10 @@ func (m *MockRepository) HasResellerReceivedBundle(ctx context.Context, reseller
 	args := m.Called(ctx, resellerID, bundleID)
 	return args.Bool(0), args.Error(1)
 }
+func (m *MockRepository) CountByStatus(ctx context.Context, status string) (int, error) {
+	args := m.Called(ctx, status)
+	return args.Int(0), args.Error(1)
+}
 
 func TestNewWarehouseUseCase(t *testing.T) {
 	// Arrange
@@ -131,4 +135,4 @@ func TestGetWarehouseItems(t *testing.T) {
 			mockRepo.AssertExpectations(t)
 		})
 	}
-} 
+}


### PR DESCRIPTION
 Description:
This PR introduces the following major features:

Admin dashboard metrics: total bundles, users, platform fees, skipped clothes.

Trust score–based auto-blacklisting for suppliers and resellers:

Users with trust score below 40 are blacklisted.

Blacklisted suppliers are restricted from posting bundles.

Rebased onto latest main to include updated order metrics and admin views.